### PR TITLE
Fix bug cannot start docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN bun run build --preset=bun
 
 FROM oven/bun:1.2.0
 WORKDIR /app
+RUN mkdir -p /app/distapp-headless
 
 RUN apt-get update && \
     apt-get install -y openjdk-11-jre-headless


### PR DESCRIPTION
Fix bug cannot start the docker container cause of missing folder `distapp-headless`. Related to the issue #12 